### PR TITLE
copy deploy method has to be two steps, so that vendor bins can find …

### DIFF
--- a/src/main/Monorepo/Build.php
+++ b/src/main/Monorepo/Build.php
@@ -96,13 +96,24 @@ class Build
 
                 foreach ($package->getBinaries() as $binary) {
 
-                    $binFile = $fullBinDir . '/' . basename($binary);
+                    // root / package / vendor / bin / binname
+                    $vendorBinTarget = $fullBinDir . '/' . basename($binary);
                     if ($config['bin-deploy-method'] == 'copy') {
-                        copy($rootDirectory. '/'. $binary, $binFile);
-                        chmod($binFile, fileperms($rootDirectory. '/'. $binary));
+                        $source = $rootDirectory. '/'. $binary;
+
+                        // root / package / vendor / vendor-name / package-name / binary-path
+                        //$target =  
+                        $target = $rootDirectory . '/' . $config['path'] . '/' . $binary;
+                        $targetDir = dirname($target);
+                        if (!file_exists($targetDir))
+                            mkdir($targetDir, 0777, true);
+
+                        copy($source, $target);
+                        chmod($target, fileperms($rootDirectory. '/'. $binary));
+                        symlink('../../'.$binary, $vendorBinTarget);
                     }
                     else {
-                        symlink($relativeRootDirectory . $binary, $binFile);
+                        symlink($relativeRootDirectory . $binary, $vendorBinTarget);
                     }
                 }
             }

--- a/tests/Monorepo/BuildTest.php
+++ b/tests/Monorepo/BuildTest.php
@@ -100,13 +100,19 @@ class BuildTest extends \PHPUnit_Framework_TestCase
         $build = new Build();
         $build->build($exampleDir);
 
-        $this->assertTrue(file_exists("$exampleDir/bar/vendor/bin/test-bin"));
-        $this->assertFalse(is_link("$exampleDir/bar/vendor/bin/test-bin"));
-        $this->assertTrue(is_executable("$exampleDir/bar/vendor/bin/test-bin"));
+        $test = function($vendorBin, $vendorSource, $symlink)
+        {
+            $this->assertTrue(file_exists($vendorSource));
+            $this->assertTrue(is_executable($vendorSource));
 
-        $this->assertTrue(file_exists("$exampleDir/foo/baz/vendor/bin/test-bin"));
-        $this->assertFalse(is_link("$exampleDir/foo/baz/vendor/bin/test-bin"));
-        $this->assertTrue(is_executable("$exampleDir/foo/baz/vendor/bin/test-bin"));
+            $this->assertTrue(file_exists($vendorBin));
+            $this->assertTrue(is_link($vendorBin));
+            $link = readlink($vendorBin);
+            $this->assertEquals($symlink, $link);
+        };
+
+        $test("$exampleDir/bar/vendor/bin/test-bin", "$exampleDir/bar/vendor/test/bin/test-bin", '../../vendor/test/bin/test-bin');
+        $test("$exampleDir/foo/baz/vendor/bin/test-bin", "$exampleDir/foo/baz/vendor/test/bin/test-bin", '../../vendor/test/bin/test-bin');
     }
 
     protected function tearDown()


### PR DESCRIPTION
…autoload.php where they expect to